### PR TITLE
[Fix] Move Reentrancy Protection to Implementation

### DIFF
--- a/protocol/contracts/mock/implementation/MockImplementation.sol
+++ b/protocol/contracts/mock/implementation/MockImplementation.sol
@@ -22,6 +22,7 @@ import "../../src/common/Implementation.sol";
 contract MockImplementation is Implementation {
     address private _registry;
     address private _owner;
+    bool private _notEntered;
 
     function registry() public view returns (IRegistry) {
         return IRegistry(_registry);
@@ -39,5 +40,21 @@ contract MockImplementation is Implementation {
         _owner = newOwner;
     }
 
+    function notEnteredE() external view returns (bool) {
+        return notEntered();
+    }
+
+    function notEntered() internal view returns (bool) {
+        return _notEntered;
+    }
+
+    function _setNotEntered(bool newNotEntered) internal {
+        _notEntered = newNotEntered;
+    }
+
     function onlyOwnerE() external onlyOwner { }
+
+    function reenters() public nonReentrant {
+        reenters();
+    }
 }

--- a/protocol/contracts/mock/stabilizer/MockStabilizerComptroller.sol
+++ b/protocol/contracts/mock/stabilizer/MockStabilizerComptroller.sol
@@ -21,10 +21,6 @@ import "../../src/stabilizer/StabilizerComptroller.sol";
 import "./MockStabilizerState.sol";
 
 contract MockStabilizerComptroller is StabilizerComptroller, MockStabilizerState {
-    constructor () public {
-        _state.oracle.ema = Decimal.one();
-    }
-
     function settleE() external {
         super._settle();
     }

--- a/protocol/contracts/src/common/IImplementation.sol
+++ b/protocol/contracts/src/common/IImplementation.sol
@@ -38,6 +38,11 @@ contract IImplementation {
          * @notice Registry containing mappings for all protocol contracts
          */
         address registry;
+
+        /**
+         * @notice Entered state for tracking call reentrancy
+         */
+        bool notEntered;
     }
 
     /**
@@ -79,4 +84,19 @@ contract IImplementation {
      * @param newOwner New owner contract
      */
     function _setOwner(address newOwner) internal;
+
+    // NON REENTRANT
+
+    /**
+     * @notice The entered status of the current call
+     * @return entered status
+     */
+    function notEntered() internal view returns (bool);
+
+    /**
+     * @notice Updates the entered status of the current call
+     * @dev Internal only
+     * @param newNotEntered New entered status
+     */
+    function _setNotEntered(bool newNotEntered) internal;
 }

--- a/protocol/contracts/src/common/Implementation.sol
+++ b/protocol/contracts/src/common/Implementation.sol
@@ -120,4 +120,50 @@ contract Implementation is IImplementation {
 
         _;
     }
+
+    // NON REENTRANT
+
+    /**
+     * @dev Prevents a contract from calling itself, directly or indirectly.
+     * Calling a `nonReentrant` function from another `nonReentrant`
+     * function is not supported. It is possible to prevent this from happening
+     * by making the `nonReentrant` function external, and make it call a
+     * `private` function that does the actual work.
+     */
+    modifier nonReentrant() {
+        // On the first call to nonReentrant, _notEntered will be true
+        require(notEntered(), "Implementation: reentrant call");
+
+        // Any calls to nonReentrant after this point will fail
+        _setNotEntered(false);
+
+        _;
+
+        // By storing the original value once again, a refund is triggered (see
+        // https://eips.ethereum.org/EIPS/eip-2200)
+        _setNotEntered(true);
+    }
+
+    // SETUP
+
+    /**
+     * @notice Hook to surface arbitrary logic to be called after deployment by owner
+     * @dev Governance hook
+     *      Does not ensure that it is only called once because it is permissioned to governance only
+     */
+    function setup() external onlyOwner {
+        // Storing an initial non-zero value makes deployment a bit more
+        // expensive, but in exchange the refund on every call to nonReentrant
+        // will be lower in amount. Since refunds are capped to a percetange of
+        // the total transaction's gas, it is best to keep them low in cases
+        // like this one, to increase the likelihood of the full refund coming
+        // into effect.
+        _setNotEntered(true);
+        _setup();
+    }
+
+    /**
+     * @notice Override to provide addition setup logic per implementation
+     */
+    function _setup() internal { }
 }

--- a/protocol/contracts/src/reserve/ReserveComptroller.sol
+++ b/protocol/contracts/src/reserve/ReserveComptroller.sol
@@ -20,7 +20,6 @@ pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 import "../Interfaces.sol";
 import "../lib/Decimal.sol";
@@ -32,7 +31,7 @@ import "./ReserveVault.sol";
  * @title ReserveComptroller
  * @notice Reserve accounting logic for managing the ESD stablecoin.
  */
-contract ReserveComptroller is ReentrancyGuard, ReserveAccessors, ReserveVault {
+contract ReserveComptroller is ReserveAccessors, ReserveVault {
     using SafeMath for uint256;
     using Decimal for Decimal.D256;
     using SafeERC20 for IERC20;

--- a/protocol/contracts/src/reserve/ReserveIssuer.sol
+++ b/protocol/contracts/src/reserve/ReserveIssuer.sol
@@ -20,7 +20,6 @@ pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 import "../Interfaces.sol";
 import "./ReserveState.sol";
@@ -29,7 +28,7 @@ import "./ReserveState.sol";
  * @title ReserveIssuer
  * @notice Logic to manage the supply of ESDS
  */
-contract ReserveIssuer is ReentrancyGuard, ReserveAccessors {
+contract ReserveIssuer is ReserveAccessors {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;
     /**
@@ -49,7 +48,7 @@ contract ReserveIssuer is ReentrancyGuard, ReserveAccessors {
      * @param account Account to mint ESDS to
      * @param amount Amount of ESDS to mint
      */
-    function mintStake(address account, uint256 amount) public onlyOwner nonReentrant {
+    function mintStake(address account, uint256 amount) public onlyOwner {
         address stake = registry().stake();
 
         IManagedToken(stake).mint(amount);
@@ -63,7 +62,7 @@ contract ReserveIssuer is ReentrancyGuard, ReserveAccessors {
      * @dev Non-reentrant
      *      Owner only - governance hook
      */
-    function burnStake() public onlyOwner nonReentrant {
+    function burnStake() public onlyOwner {
         address stake = registry().stake();
 
         uint256 stakeBalance = IERC20(stake).balanceOf(address(this));

--- a/protocol/contracts/src/reserve/ReserveState.sol
+++ b/protocol/contracts/src/reserve/ReserveState.sol
@@ -280,4 +280,22 @@ contract ReserveAccessors is IImplementation, ReserveAdmin {
     function _setOwner(address newOwner) internal {
         _state.implementation.owner = newOwner;
     }
+
+
+    /**
+     * @notice The entered status of the current call
+     * @return entered status
+     */
+    function notEntered() internal view returns (bool) {
+        return _state.implementation.notEntered;
+    }
+
+    /**
+     * @notice Updates the entered status of the current call
+     * @dev Internal only
+     * @param newNotEntered New entered status
+     */
+    function _setNotEntered(bool newNotEntered) internal {
+        _state.implementation.notEntered = newNotEntered;
+    }
 }

--- a/protocol/contracts/src/reserve/ReserveSwapper.sol
+++ b/protocol/contracts/src/reserve/ReserveSwapper.sol
@@ -20,7 +20,6 @@ pragma experimental ABIEncoderV2;
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
-import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 import "../Interfaces.sol";
 import "./ReserveComptroller.sol";
@@ -30,7 +29,7 @@ import "./ReserveState.sol";
  * @title ReserveSwapper
  * @notice Logic for managing outstanding limit orders, allow the reserve to swap its held tokens
  */
-contract ReserveSwapper is ReentrancyGuard, ReserveComptroller {
+contract ReserveSwapper is ReserveComptroller {
     using SafeMath for uint256;
     using Decimal for Decimal.D256;
     using SafeERC20 for IERC20;

--- a/protocol/contracts/src/stabilizer/StabilizerComptroller.sol
+++ b/protocol/contracts/src/stabilizer/StabilizerComptroller.sol
@@ -109,16 +109,15 @@ contract StabilizerComptroller is StabilizerAccessors, StabilizerToken {
     // FLYWHEEL
 
     /**
-     * @notice The stabilizer's current effective reward rate
-     * @dev In terms of % of the totalUnderlying per day
-     *      Uses EMA floored at the current reserve redemption price and maxed at 1.00
-     * @return Current effective reward rate
+     * @notice Initializes logic for the stabilizer
+     * @dev Initializes oracle to track the ESD price
+     *      Will revert if oracle has already been setup - enforces a single initialization
      */
-    function setup() external onlyOwner {
+    function _setup() internal {
         IOracle oracle = IOracle(registry().oracle());
         address dollar = registry().dollar();
 
-        require(!oracle.setupFor(dollar), "StabilizerComptroller: already setup");
+        require(!oracle.setupFor(dollar), "StabilizerImpl: already setup");
 
         oracle.setup(dollar);
         _state.oracle.ema = Decimal.one();

--- a/protocol/contracts/src/stabilizer/StabilizerImpl.sol
+++ b/protocol/contracts/src/stabilizer/StabilizerImpl.sol
@@ -27,4 +27,4 @@ import "../common/Implementation.sol";
  * @notice Top-level Stabilizer contract that extends all other stabilizer sub-contracts
  * @dev This contract should be used an implementation contract for an AdminUpgradeabilityProxy
  */
-contract StabilizerImpl is Implementation, StabilizerToken, StabilizerComptroller { }
+contract StabilizerImpl is StabilizerToken, StabilizerComptroller { }

--- a/protocol/contracts/src/stabilizer/StabilizerState.sol
+++ b/protocol/contracts/src/stabilizer/StabilizerState.sol
@@ -351,4 +351,21 @@ contract StabilizerAccessors is IImplementation, StabilizerAdmin {
     function _setOwner(address newOwner) internal {
         _state.implementation.owner = newOwner;
     }
+
+    /**
+     * @notice The entered status of the current call
+     * @return entered status
+     */
+    function notEntered() internal view returns (bool) {
+        return _state.implementation.notEntered;
+    }
+
+    /**
+     * @notice Updates the entered status of the current call
+     * @dev Internal only
+     * @param newNotEntered New entered status
+     */
+    function _setNotEntered(bool newNotEntered) internal {
+        _state.implementation.notEntered = newNotEntered;
+    }
 }

--- a/protocol/test/implementation/Implementation.test.js
+++ b/protocol/test/implementation/Implementation.test.js
@@ -169,4 +169,41 @@ describe('Implementation', function () {
       });
     });
   });
+
+  describe('setup', function () {
+    describe('before set', function () {
+      it('is zero address', async function () {
+        expect(await this.implementation.notEnteredE()).to.be.equal(false);
+      });
+
+      describe('when called', function () {
+        beforeEach('call', async function () {
+          this.result = await this.implementation.setup({from: ownerAddress});
+          this.txHash = this.result.tx
+        });
+
+        it('sets new value', async function () {
+          expect(await this.implementation.notEnteredE()).to.be.equal(true);
+        });
+      });
+
+      describe('not owner', function () {
+        it('reverts', async function () {
+          await expectRevert(
+            this.implementation.setup({from: userAddress}),
+            "Implementation: not owner");
+        });
+      });
+    });
+  });
+
+  describe('reenters', function () {
+    describe('not owner', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.implementation.reenters({from: ownerAddress}),
+          "Implementation: reentrant call");
+      });
+    });
+  });
 });

--- a/protocol/test/reserve/ReserveComptroller.test.js
+++ b/protocol/test/reserve/ReserveComptroller.test.js
@@ -28,6 +28,7 @@ describe('ReserveComptroller', function () {
     await this.cUsdc.setExchangeRate(ONE_USDC);
     this.comptroller = await MockReserveComptroller.new({from: ownerAddress}, {from: ownerAddress});
     await this.comptroller.takeOwnership({from: ownerAddress});
+    await this.comptroller.setup({from: ownerAddress});
     await this.comptroller.setRegistry(this.registry.address, {from: ownerAddress});
     await this.dollar.transferOwnership(this.comptroller.address, {from: ownerAddress});
     await this.registry.setUsdc(this.collateral.address, {from: ownerAddress});

--- a/protocol/test/reserve/ReserveIssuer.test.js
+++ b/protocol/test/reserve/ReserveIssuer.test.js
@@ -18,6 +18,7 @@ describe('ReserveIssuer', function () {
     this.stake = await Stake.new({from: ownerAddress});
     this.issuer = await MockReserveIssuer.new({from: ownerAddress});
     await this.issuer.takeOwnership({from: ownerAddress});
+    await this.issuer.setup({from: ownerAddress});
     await this.issuer.setRegistry(this.registry.address, {from: ownerAddress});
     await this.registry.setStake(this.stake.address, {from: ownerAddress});
     await this.stake.transferOwnership(this.issuer.address, {from: ownerAddress});

--- a/protocol/test/reserve/ReserveState.test.js
+++ b/protocol/test/reserve/ReserveState.test.js
@@ -13,6 +13,7 @@ describe('ReserveState', function () {
   beforeEach(async function () {
     this.accessors = await MockReserveState.new({from: ownerAddress});
     await this.accessors.takeOwnership({from: ownerAddress});
+    await this.accessors.setup({from: ownerAddress});
   });
 
   /**

--- a/protocol/test/reserve/ReserveSwapper.test.js
+++ b/protocol/test/reserve/ReserveSwapper.test.js
@@ -20,6 +20,7 @@ describe('ReserveSwapper', function () {
     this.tokenB = await MockToken.new("USD//C", "USDC", 6, {from: ownerAddress});
     this.swapper = await MockReserveSwapper.new({from: ownerAddress});
     await this.swapper.takeOwnership({from: ownerAddress});
+    await this.swapper.setup({from: ownerAddress});
     await this.swapper.setRegistry(this.registry.address, {from: ownerAddress});
   });
 

--- a/protocol/test/reserve/ReserveVault.test.js
+++ b/protocol/test/reserve/ReserveVault.test.js
@@ -28,6 +28,7 @@ describe('ReserveVault', function () {
     await this.cUsdc.setExchangeRate(ONE_USDC);
     this.vault = await MockReserveVault.new({from: ownerAddress});
     await this.vault.takeOwnership({from: ownerAddress});
+    await this.vault.setup({from: ownerAddress});
     await this.vault.setRegistry(this.registry.address, {from: ownerAddress});
     await this.registry.setUsdc(this.collateral.address, {from: ownerAddress});
     await this.registry.setCUsdc(this.cUsdc.address, {from: ownerAddress});

--- a/protocol/test/stabilizer/StabilizerComptroller.test.js
+++ b/protocol/test/stabilizer/StabilizerComptroller.test.js
@@ -45,6 +45,11 @@ describe('StabilizerComptroller', function () {
   });
 
   describe('before setup', function () {
+    it('initializes ema', async function () {
+      const ema = await this.comptroller.ema();
+      expect(ema.value).to.be.bignumber.equal(new BN(0));
+    });
+
     describe('when called', function () {
       beforeEach('call', async function () {
         await this.comptroller.setup({from: ownerAddress});

--- a/protocol/test/stabilizer/StabilizerState.test.js
+++ b/protocol/test/stabilizer/StabilizerState.test.js
@@ -13,6 +13,7 @@ describe('StabilizerState', function () {
   beforeEach(async function () {
     this.accessors = await MockStabilizerState.new({from: ownerAddress});
     await this.accessors.takeOwnership({from: ownerAddress});
+    await this.accessors.setup({from: ownerAddress});
   });
 
   /**


### PR DESCRIPTION
Previously we were using the OZ `ReentrancyGuard` for reentrancy protection throughout `Reserve`. This had two side-effects:

- `ReentrancyGuard` has its own state which is not compatible with the general upgrade pattern of `Reserve` and `Stabilizer`. This wouldn't immediately cause issues, but would make state upgrades much harder to validate.
- `ReentrancyGuard` has constructor logic that is not run when it is behind an implementation proxy. This causes all `nonReentrant` calls to fail.

This PR refactors the logic from `ReentrancyGuard` and includes it in the common `Implementation` helper, in a similar vein as `Ownable`.

- Adds reentrancy guard logic to `Implementation`
- Removes usage of OZ `ReentrancyGuard` within upgradeable contracts
- Removes unnecessary usage of `nonReentrant` within `ReserveIssuer`
- Implements required hooks in `Reserve` and `Stabilizer` for `Implementation` updates
- Fixes test for `Stabilizer` `setup()`