### PR TITLE
[Fix] Rounding error on mint()

### DIFF
--- a/protocol/contracts/src/reserve/ReserveComptroller.sol
+++ b/protocol/contracts/src/reserve/ReserveComptroller.sol
@@ -108,6 +108,10 @@ contract ReserveComptroller is ReentrancyGuard, ReserveAccessors, ReserveVault {
      */
     function mint(uint256 amount) external nonReentrant {
         uint256 costAmount = _toUsdcAmount(amount);
+
+        // Take the ceiling to ensure no "free" ESD is minted
+        costAmount = _fromUsdcAmount(costAmount) == amount ? costAmount : costAmount.add(1);
+
         _transferFrom(registry().usdc(), msg.sender, address(this), costAmount);
         _supplyVault(costAmount);
         _mintDollar(msg.sender, amount);


### PR DESCRIPTION
Currently the `mint()` function takes in an amount in `ESD` at 18 decimals.

This amount is divided by `10^12` to produce the `USDC` amount that will be transferred in from the user. Due to this loss of precision up to `10^12 - 1 wei of ESD` may be minted without paying any USDC.

This is not an attackable vector since the amount gained is extremely small per transaction and any reserve ratio "divot" would be filled in fairly quickly by the yield on the managed `USDC`, but it's still something we'd like to prevent for cleanliness.

This PR takes the ceiling of the resulting `usdcAmount` instead of the naive floor to prevent such inconsistencies.