### PR TITLE
[OZ][N07] Misleading or erroneous docstrings

### DIFF
--- a/protocol/contracts/src/reserve/ReserveComptroller.sol
+++ b/protocol/contracts/src/reserve/ReserveComptroller.sol
@@ -81,7 +81,7 @@ contract ReserveComptroller is ReentrancyGuard, ReserveAccessors, ReserveVault {
     }
 
     /**
-     * @notice Rhe ratio of the {reserveBalance} to total ESD issuance
+     * @notice The ratio of the {reserveBalance} to total ESD issuance
      * @dev Assumes 1 ESD = 1 USDC, normalizing for decimals
      * @return Reserve ratio
      */

--- a/protocol/contracts/src/reserve/ReserveState.sol
+++ b/protocol/contracts/src/reserve/ReserveState.sol
@@ -130,7 +130,7 @@ contract ReserveAdmin is Implementation, ReserveState {
 
     /**
      * @notice Current redemption tax for artificially lowering the {redeemPrice}
-     * @return Reserve debt
+     * @return Redemption tax
      */
     function redemptionTax() public view returns (Decimal.D256 memory) {
         return _state.redemptionTax;

--- a/protocol/contracts/src/reserve/ReserveVault.sol
+++ b/protocol/contracts/src/reserve/ReserveVault.sol
@@ -82,7 +82,7 @@ contract ReserveVault is ReserveAccessors {
     }
 
     /**
-     * @notice Claims all available governance rewards the external protocol
+     * @notice Claims all available governance rewards from the external protocol
      * @dev Owner only - governance hook
      *      Claims COMP accrued from lending on the USDC pool
      */
@@ -144,7 +144,7 @@ contract ICErc20 {
 }
 
 /**
- * @title ICErc20
+ * @title IComptroller
  * @dev Compound IComptroller interface
  */
 contract IComptroller {


### PR DESCRIPTION
- Fixes all listed typos except `StabilizerComptroller`'s, which was already fixed in #1.