### PR TITLE
[OZ][L12] Centralized registry is not adopted in the whole code base

### DIFF
--- a/protocol/contracts/mock/common/MockContract.sol
+++ b/protocol/contracts/mock/common/MockContract.sol
@@ -1,0 +1,21 @@
+/*
+    Copyright 2020, 2021 Empty Set Squad <emptysetsquad@protonmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity 0.5.17;
+pragma experimental ABIEncoderV2;
+
+// Dummy contract to pass the Address.isContract check in Registry
+contract MockContract { }

--- a/protocol/contracts/src/registry/RegistryAccessor.sol
+++ b/protocol/contracts/src/registry/RegistryAccessor.sol
@@ -1,0 +1,56 @@
+/*
+    Copyright 2021 Empty Set Squad <emptysetsquad@protonmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity 0.5.17;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "../Interfaces.sol";
+
+/**
+ * @title RegistryAccessor
+ * @notice Grants access to store and retrieve data from the protocol Registry
+ * @dev Registry value updatable by owner if timelocks match
+ */
+contract RegistryAccessor is Ownable {
+    /**
+     * @notice Emitted when {registry} is updated with `newRegistry`
+     */
+    event RegistryUpdate(address newRegistry);
+
+    /**
+     * @notice Address of the Continuous ESDS contract registry
+     */
+    IRegistry public registry;
+
+    /**
+     * @notice Updates the registry contract
+     * @dev Owner only - governance hook
+     *      If registry is already set, the new registry's timelock must match the current's
+     * @param newRegistry New registry contract
+     */
+    function setRegistry(address newRegistry) public onlyOwner {
+        require(newRegistry != address(0), "RegistryAccessor: zero address");
+        require(
+            address(registry) == address(0) || IRegistry(newRegistry).timelock() == registry.timelock(),
+            "RegistryAccessor: timelocks must match"
+        );
+
+        registry = IRegistry(newRegistry);
+
+        emit RegistryUpdate(newRegistry);
+    }
+}

--- a/protocol/test/registry/RegistryAccessor.test.js
+++ b/protocol/test/registry/RegistryAccessor.test.js
@@ -1,0 +1,96 @@
+const { accounts, contract } = require('@openzeppelin/test-environment');
+
+const { BN, expectRevert, expectEvent } = require('@openzeppelin/test-helpers');
+const { expect } = require('chai');
+
+const RegistryAccessor = contract.fromArtifact('RegistryAccessor');
+const Registry = contract.fromArtifact('Registry');
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+describe('RegistryAccessor', function () {
+  const [ ownerAddress, userAddress, timelockA, timelockB] = accounts;
+
+  beforeEach(async function () {
+    this.accessor = await RegistryAccessor.new({from: ownerAddress});
+    
+    this.registryA = await Registry.new({from: ownerAddress});
+    await this.registryA.setTimelock(timelockA, {from: ownerAddress});
+    this.registryB = await Registry.new({from: ownerAddress});
+    await this.registryB.setTimelock(timelockA, {from: ownerAddress});
+    this.registryC = await Registry.new({from: ownerAddress});
+    await this.registryC.setTimelock(timelockB, {from: ownerAddress});
+  });
+
+  describe('setRegistry', function () {
+    describe('before set', function () {
+      it('is zero address', async function () {
+        expect(await this.accessor.registry()).to.be.equal(ZERO_ADDRESS);
+      });
+
+      describe('when called', function () {
+        beforeEach('call', async function () {
+          this.result = await this.accessor.setRegistry(this.registryA.address, {from: ownerAddress});
+          this.txHash = this.result.tx
+        });
+
+        it('sets new value', async function () {
+          expect(await this.accessor.registry()).to.be.equal(this.registryA.address);
+        });
+
+        it('emits RegistryUpdate event', async function () {
+          const event = await expectEvent.inTransaction(this.txHash, RegistryAccessor, 'RegistryUpdate', {
+            newRegistry: this.registryA.address,
+          });
+        });
+      });
+    });
+
+    describe('after set', function () {
+      beforeEach('call', async function () {
+        await this.accessor.setRegistry(this.registryA.address, {from: ownerAddress});
+      });
+
+      describe('same timelock', function () {
+        beforeEach('call', async function () {
+          this.result = await this.accessor.setRegistry(this.registryB.address, {from: ownerAddress});
+          this.txHash = this.result.tx;
+        });
+
+        it('sets new value', async function () {
+          expect(await this.accessor.registry()).to.be.equal(this.registryB.address);
+        });
+
+        it('emits RegistryUpdate event', async function () {
+          const event = await expectEvent.inTransaction(this.txHash, RegistryAccessor, 'RegistryUpdate', {
+            newRegistry: this.registryB.address,
+          });
+        });
+      });
+
+      describe('different timelock', function () {
+        it('reverts', async function () {
+          await expectRevert(
+            this.accessor.setRegistry(this.registryC.address, {from: ownerAddress}),
+            "RegistryAccessor: timelocks must match");
+        });
+      });
+    });
+
+    describe('not owner', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.accessor.setRegistry(this.registryA.address, {from: userAddress}),
+          "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('zero address', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.accessor.setRegistry(ZERO_ADDRESS, {from: ownerAddress}),
+          "RegistryAccessor: zero address");
+      });
+    });
+  });
+});


### PR DESCRIPTION
Depends on #14 

- Updates `Incentivizer` to store `registry` instead of `reserve` directly.
- Updates `Migrator` to store `registry` instead of `stake` and `reserve` directly.