### PR TITLE
[OZ][L08] Lack of input validation

### DIFF
--- a/protocol/contracts/src/incentivizer/Incentivizer.sol
+++ b/protocol/contracts/src/incentivizer/Incentivizer.sol
@@ -291,6 +291,8 @@ contract Incentivizer is RegistryAccessor, ReentrancyGuard {
      * @param amount Amount of underlying tokens for the caller to deposit
      */
     function stake(uint256 amount) external nonReentrant {
+        require(amount != 0, "Incentivizer: zero amount");
+
         _settleAccount(msg.sender);
 
         // Increment account balance
@@ -309,6 +311,8 @@ contract Incentivizer is RegistryAccessor, ReentrancyGuard {
      * @param amount Amount of underlying tokens for the caller to withdraw
      */
     function withdraw(uint256 amount) public nonReentrant {
+        require(amount != 0, "Incentivizer: zero amount");
+
         _settleAccount(msg.sender);
 
         // Decrement account balance

--- a/protocol/test/incentivizer/Incentivizer.test.js
+++ b/protocol/test/incentivizer/Incentivizer.test.js
@@ -342,6 +342,14 @@ describe('Incentivizer', function () {
         await this.underlying.approve(this.incentivizer.address, ONE_UNIT.muln(1000), {from: userAddress});
       });
 
+      describe('zero amount', function () {
+        it('reverts', async function () {
+          await expectRevert(
+            this.incentivizer.stake(new BN(0), {from: userAddress}),
+            "Incentivizer: zero amount");
+        });
+      });
+
       describe('simple', function () {
         beforeEach(async function () {
           this.result = await this.incentivizer.stake(ONE_UNIT.muln(1000), {from: userAddress});
@@ -489,6 +497,18 @@ describe('Incentivizer', function () {
       beforeEach(async function () {
         await this.underlying.mint(userAddress, ONE_UNIT.muln(1000));
         await this.underlying.approve(this.incentivizer.address, ONE_UNIT.muln(1000), {from: userAddress});
+      });
+
+      describe('zero amount', function () {
+        beforeEach(async function () {
+          await this.incentivizer.stake(ONE_UNIT.muln(1000), {from: userAddress});
+        });
+
+        it('reverts', async function () {
+          await expectRevert(
+            this.incentivizer.withdraw(new BN(0), {from: userAddress}),
+            "Incentivizer: zero amount");
+        });
       });
 
       describe('simple', function () {
@@ -1038,6 +1058,14 @@ describe('Incentivizer', function () {
         await this.underlying.approve(this.incentivizer.address, ONE_UNIT.muln(1000), {from: userAddress});
       });
 
+      describe('zero amount', function () {
+        it('reverts', async function () {
+          await expectRevert(
+            this.incentivizer.stake(new BN(0), {from: userAddress}),
+            "Incentivizer: zero amount");
+        });
+      });
+
       describe('simple', function () {
         beforeEach(async function () {
           this.result = await this.incentivizer.stake(ONE_UNIT.muln(1000), {from: userAddress});
@@ -1181,6 +1209,18 @@ describe('Incentivizer', function () {
       beforeEach(async function () {
         await this.underlying.mint(userAddress, ONE_UNIT.muln(1000));
         await this.underlying.approve(this.incentivizer.address, ONE_UNIT.muln(1000), {from: userAddress});
+      });
+
+      describe('zero amount', function () {
+        beforeEach(async function () {
+          await this.incentivizer.stake(ONE_UNIT.muln(1000), {from: userAddress});
+        });
+
+        it('reverts', async function () {
+          await expectRevert(
+            this.incentivizer.withdraw(new BN(0), {from: userAddress}),
+            "Incentivizer: zero amount");
+        });
       });
 
       describe('simple', function () {


### PR DESCRIPTION
- Adds `amount != 0` validation for `Incentivizer`'s `stake` and `withdraw` functions.
- Leaves `GovernorAlpha` and `Stake` as-is to not modify forked code unnecessarily.