### PR TITLE
[OZ][M12] Wrong arithmetic operation when normalizing prices

### DIFF
--- a/protocol/contracts/src/oracle/Oracle.sol
+++ b/protocol/contracts/src/oracle/Oracle.sol
@@ -287,7 +287,7 @@ contract Oracle is IOracle, Ownable {
         if (decimals > 6) {
             return price.mul(10 ** (uint256(decimals) - 6));
         } else if (decimals < 6) {
-            return price.mul(10 ** (6 - uint256(decimals)));
+            return price.div(10 ** (6 - uint256(decimals)));
         }
         return price;
     }


### PR DESCRIPTION
- Fixes arithmetic to properly support tokens with `decimals() < 6`.