### PR TITLE
[OZ][M10] Updating storage variables could soft-brick the protocol

### DIFF
--- a/protocol/contracts/mock/reserve/MockSettableStabilizer.sol
+++ b/protocol/contracts/mock/reserve/MockSettableStabilizer.sol
@@ -1,0 +1,32 @@
+/*
+    Copyright 2021 Empty Set Squad <emptysetsquad@protonmail.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+*/
+
+pragma solidity 0.5.17;
+pragma experimental ABIEncoderV2;
+
+import "../../src/Interfaces.sol";
+
+contract MockSettableStabilizer {
+    IReserve internal _reserve;
+
+    function set(IReserve reserve) external {
+        _reserve = reserve;
+    }
+
+    function borrow(uint256 amount) external {
+        _reserve.borrow(amount);
+    }
+}

--- a/protocol/contracts/src/common/Implementation.sol
+++ b/protocol/contracts/src/common/Implementation.sol
@@ -17,6 +17,7 @@
 pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
+import "@openzeppelin/contracts/utils/Address.sol";
 import "../Interfaces.sol";
 import "./IImplementation.sol";
 
@@ -75,7 +76,8 @@ contract Implementation is IImplementation {
 
         require(newRegistry != address(0), "Implementation: zero address");
         require(
-            address(registry) == address(0) || IRegistry(newRegistry).timelock() == registry.timelock(),
+            (address(registry) == address(0) && Address.isContract(newRegistry)) ||
+                IRegistry(newRegistry).timelock() == registry.timelock(),
             "Implementation: timelocks must match"
         );
 
@@ -105,7 +107,8 @@ contract Implementation is IImplementation {
      * @param newOwner New owner contract
      */
     function setOwner(address newOwner) external onlyOwner {
-        require(newOwner != address(0), "Implementation: zero address");
+        require(newOwner != address(this), "Implementation: this");
+        require(Address.isContract(newOwner), "Implementation: not contract");
 
         _setOwner(newOwner);
 

--- a/protocol/contracts/src/registry/Registry.sol
+++ b/protocol/contracts/src/registry/Registry.sol
@@ -18,6 +18,7 @@ pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/ownership/Ownable.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 import "../Interfaces.sol";
 
 /**
@@ -78,7 +79,7 @@ contract Registry is IRegistry, Ownable {
     address public timelock;
 
     /**
-     * @notice Migration contract to bride v1 assets with current system
+     * @notice Migration contract to bridge v1 assets with current system
      */
     address public migrator;
 
@@ -89,7 +90,7 @@ contract Registry is IRegistry, Ownable {
      * @dev Owner only - governance hook
      * @param newValue New address to register
      */
-    function setUsdc(address newValue) external onlyOwner {
+    function setUsdc(address newValue) external validate(newValue) onlyOwner {
         usdc = newValue;
         emit Registration("USDC", newValue);
     }
@@ -99,7 +100,7 @@ contract Registry is IRegistry, Ownable {
      * @dev Owner only - governance hook
      * @param newValue New address to register
      */
-    function setCUsdc(address newValue) external onlyOwner {
+    function setCUsdc(address newValue) external validate(newValue) onlyOwner {
         cUsdc = newValue;
         emit Registration("CUSDC", newValue);
     }
@@ -109,7 +110,7 @@ contract Registry is IRegistry, Ownable {
      * @dev Owner only - governance hook
      * @param newValue New address to register
      */
-    function setDollar(address newValue) external onlyOwner {
+    function setDollar(address newValue) external validate(newValue) onlyOwner {
         dollar = newValue;
         emit Registration("DOLLAR", newValue);
     }
@@ -119,7 +120,7 @@ contract Registry is IRegistry, Ownable {
      * @dev Owner only - governance hook
      * @param newValue New address to register
      */
-    function setStake(address newValue) external onlyOwner {
+    function setStake(address newValue) external validate(newValue) onlyOwner {
         stake = newValue;
         emit Registration("STAKE", newValue);
     }
@@ -129,7 +130,7 @@ contract Registry is IRegistry, Ownable {
      * @dev Owner only - governance hook
      * @param newValue New address to register
      */
-    function setReserve(address newValue) external onlyOwner {
+    function setReserve(address newValue) external validate(newValue) onlyOwner {
         reserve = newValue;
         emit Registration("RESERVE", newValue);
     }
@@ -139,7 +140,7 @@ contract Registry is IRegistry, Ownable {
      * @dev Owner only - governance hook
      * @param newValue New address to register
      */
-    function setStabilizer(address newValue) external onlyOwner {
+    function setStabilizer(address newValue) external validate(newValue) onlyOwner {
         stabilizer = newValue;
         emit Registration("STABILIZER", newValue);
     }
@@ -149,7 +150,7 @@ contract Registry is IRegistry, Ownable {
      * @dev Owner only - governance hook
      * @param newValue New address to register
      */
-    function setOracle(address newValue) external onlyOwner {
+    function setOracle(address newValue) external validate(newValue) onlyOwner {
         oracle = newValue;
         emit Registration("ORACLE", newValue);
     }
@@ -159,7 +160,7 @@ contract Registry is IRegistry, Ownable {
      * @dev Owner only - governance hook
      * @param newValue New address to register
      */
-    function setGovernor(address newValue) external onlyOwner {
+    function setGovernor(address newValue) external validate(newValue) onlyOwner {
         governor = newValue;
         emit Registration("GOVERNOR", newValue);
     }
@@ -170,7 +171,7 @@ contract Registry is IRegistry, Ownable {
      *      Does not automatically update the owner of all owned protocol contracts
      * @param newValue New address to register
      */
-    function setTimelock(address newValue) external onlyOwner {
+    function setTimelock(address newValue) external validate(newValue) onlyOwner {
         timelock = newValue;
         emit Registration("TIMELOCK", newValue);
     }
@@ -180,8 +181,20 @@ contract Registry is IRegistry, Ownable {
      * @dev Owner only - governance hook
      * @param newValue New address to register
      */
-    function setMigrator(address newValue) external onlyOwner {
+    function setMigrator(address newValue) external validate(newValue) onlyOwner {
         migrator = newValue;
         emit Registration("MIGRATOR", newValue);
+    }
+
+    /**
+     * @notice Ensures the newly supplied value is a deployed contract
+     * @param newValue New address to validate
+     */
+    //TODO: Add this check to setRegistry in Implementation and possibly other setters as well
+    modifier validate(address newValue) {
+        require(newValue != address(this), "Registry: this");
+        require(Address.isContract(newValue), "Registry: not contract");
+
+        _;
     }
 }

--- a/protocol/contracts/src/registry/RegistryAccessor.sol
+++ b/protocol/contracts/src/registry/RegistryAccessor.sol
@@ -17,6 +17,7 @@
 pragma solidity 0.5.17;
 pragma experimental ABIEncoderV2;
 
+import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/ownership/Ownable.sol";
 import "../Interfaces.sol";
 
@@ -45,7 +46,8 @@ contract RegistryAccessor is Ownable {
     function setRegistry(address newRegistry) public onlyOwner {
         require(newRegistry != address(0), "RegistryAccessor: zero address");
         require(
-            address(registry) == address(0) || IRegistry(newRegistry).timelock() == registry.timelock(),
+            (address(registry) == address(0) && Address.isContract(newRegistry)) ||
+                IRegistry(newRegistry).timelock() == registry.timelock(),
             "RegistryAccessor: timelocks must match"
         );
 

--- a/protocol/test/registry/Registry.test.js
+++ b/protocol/test/registry/Registry.test.js
@@ -4,30 +4,40 @@ const { BN, expectRevert } = require('@openzeppelin/test-helpers');
 const { expect } = require('chai');
 
 const Registry = contract.fromArtifact('Registry');
+const MockContract = contract.fromArtifact('MockContract');
 
 describe('Registry', function () {
   const [ ownerAddress, userAddress, testAddress] = accounts;
 
   beforeEach(async function () {
+    this.testContract = await MockContract.new({from: ownerAddress});
     this.registry = await Registry.new({from: ownerAddress});
   });
 
   describe('setUsdc', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setUsdc(testAddress, {from: ownerAddress});
+        await this.registry.setUsdc(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.usdc()).to.be.equal(testAddress);
+        expect(await this.registry.usdc()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setUsdc(testAddress, {from: userAddress}),
+          this.registry.setUsdc(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setUsdc(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });
@@ -35,19 +45,27 @@ describe('Registry', function () {
   describe('setCUsdc', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setCUsdc(testAddress, {from: ownerAddress});
+        await this.registry.setCUsdc(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.cUsdc()).to.be.equal(testAddress);
+        expect(await this.registry.cUsdc()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setCUsdc(testAddress, {from: userAddress}),
+          this.registry.setCUsdc(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setCUsdc(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });
@@ -55,19 +73,27 @@ describe('Registry', function () {
   describe('setDollar', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setDollar(testAddress, {from: ownerAddress});
+        await this.registry.setDollar(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.dollar()).to.be.equal(testAddress);
+        expect(await this.registry.dollar()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setDollar(testAddress, {from: userAddress}),
+          this.registry.setDollar(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setDollar(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });
@@ -75,19 +101,27 @@ describe('Registry', function () {
   describe('setStake', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setStake(testAddress, {from: ownerAddress});
+        await this.registry.setStake(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.stake()).to.be.equal(testAddress);
+        expect(await this.registry.stake()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setStake(testAddress, {from: userAddress}),
+          this.registry.setStake(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setStake(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });
@@ -95,19 +129,27 @@ describe('Registry', function () {
   describe('setReserve', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setReserve(testAddress, {from: ownerAddress});
+        await this.registry.setReserve(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.reserve()).to.be.equal(testAddress);
+        expect(await this.registry.reserve()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setReserve(testAddress, {from: userAddress}),
+          this.registry.setReserve(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setReserve(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });
@@ -115,19 +157,27 @@ describe('Registry', function () {
   describe('setStabilizer', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setStabilizer(testAddress, {from: ownerAddress});
+        await this.registry.setStabilizer(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.stabilizer()).to.be.equal(testAddress);
+        expect(await this.registry.stabilizer()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setStabilizer(testAddress, {from: userAddress}),
+          this.registry.setStabilizer(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setStabilizer(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });
@@ -135,19 +185,27 @@ describe('Registry', function () {
   describe('setOracle', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setOracle(testAddress, {from: ownerAddress});
+        await this.registry.setOracle(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.oracle()).to.be.equal(testAddress);
+        expect(await this.registry.oracle()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setOracle(testAddress, {from: userAddress}),
+          this.registry.setOracle(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setOracle(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });
@@ -155,19 +213,27 @@ describe('Registry', function () {
   describe('setGovernor', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setGovernor(testAddress, {from: ownerAddress});
+        await this.registry.setGovernor(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.governor()).to.be.equal(testAddress);
+        expect(await this.registry.governor()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setGovernor(testAddress, {from: userAddress}),
+          this.registry.setGovernor(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setGovernor(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });
@@ -175,19 +241,27 @@ describe('Registry', function () {
   describe('setTimelock', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setTimelock(testAddress, {from: ownerAddress});
+        await this.registry.setTimelock(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.timelock()).to.be.equal(testAddress);
+        expect(await this.registry.timelock()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setTimelock(testAddress, {from: userAddress}),
+          this.registry.setTimelock(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setTimelock(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });
@@ -195,19 +269,27 @@ describe('Registry', function () {
   describe('setMigrator', function () {
     describe('when called', function () {
       beforeEach('call', async function () {
-        await this.registry.setMigrator(testAddress, {from: ownerAddress});
+        await this.registry.setMigrator(this.testContract.address, {from: ownerAddress});
       });
 
       it('sets new value', async function () {
-        expect(await this.registry.migrator()).to.be.equal(testAddress);
+        expect(await this.registry.migrator()).to.be.equal(this.testContract.address);
       });
     });
 
-    describe('when called erroneously', function () {
+    describe('when not owner', function () {
       it('reverts', async function () {
         await expectRevert(
-          this.registry.setMigrator(testAddress, {from: userAddress}),
+          this.registry.setMigrator(this.testContract.address, {from: userAddress}),
           "Ownable: caller is not the owner");
+      });
+    });
+
+    describe('when not contract', function () {
+      it('reverts', async function () {
+        await expectRevert(
+          this.registry.setMigrator(testAddress, {from: ownerAddress}),
+          "Registry: not contract");
       });
     });
   });

--- a/protocol/test/registry/RegistryAccessor.test.js
+++ b/protocol/test/registry/RegistryAccessor.test.js
@@ -5,21 +5,25 @@ const { expect } = require('chai');
 
 const RegistryAccessor = contract.fromArtifact('RegistryAccessor');
 const Registry = contract.fromArtifact('Registry');
+const Timelock = contract.fromArtifact('Timelock');
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 describe('RegistryAccessor', function () {
-  const [ ownerAddress, userAddress, timelockA, timelockB] = accounts;
+  const [ ownerAddress, userAddress] = accounts;
 
   beforeEach(async function () {
+    this.timelockA = await Timelock.new(ownerAddress, 86400 * 2, {from: ownerAddress});
+    this.timelockB = await Timelock.new(ownerAddress, 86400 * 2, {from: ownerAddress});
+
     this.accessor = await RegistryAccessor.new({from: ownerAddress});
     
     this.registryA = await Registry.new({from: ownerAddress});
-    await this.registryA.setTimelock(timelockA, {from: ownerAddress});
+    await this.registryA.setTimelock(this.timelockA.address, {from: ownerAddress});
     this.registryB = await Registry.new({from: ownerAddress});
-    await this.registryB.setTimelock(timelockA, {from: ownerAddress});
+    await this.registryB.setTimelock(this.timelockA.address, {from: ownerAddress});
     this.registryC = await Registry.new({from: ownerAddress});
-    await this.registryC.setTimelock(timelockB, {from: ownerAddress});
+    await this.registryC.setTimelock(this.timelockB.address, {from: ownerAddress});
   });
 
   describe('setRegistry', function () {


### PR DESCRIPTION
Depends on #8.

- Adds `Address.isContract()` checks to every `Registry` parameter setter.
- Adds `Address.isContract()` check to `setOwner()` in `Implementation`. 