### PR TITLE
[OZ][M01] Documentation issues

### DIFF
--- a/protocol/contracts/src/reserve/ReserveComptroller.sol
+++ b/protocol/contracts/src/reserve/ReserveComptroller.sol
@@ -94,6 +94,7 @@ contract ReserveComptroller is ReentrancyGuard, ReserveAccessors, ReserveVault {
      * @notice The price that one ESD can currently be sold to the reserve for
      * @dev Returned as a Decimal.D256
      *      Normalizes for decimals (e.g. 1.00 USDC == Decimal.one())
+     *      Equivalent to the current reserve ratio less the current redemption tax (if any)
      * @return Current ESD redemption price
      */
     function redeemPrice() public view returns (Decimal.D256 memory) {
@@ -104,6 +105,7 @@ contract ReserveComptroller is ReentrancyGuard, ReserveAccessors, ReserveVault {
      * @notice Mints `amount` ESD to the caller in exchange for an equivalent amount of USDC
      * @dev Non-reentrant
      *      Normalizes for decimals
+     *      Caller must approve reserve to transfer USDC
      * @param amount Amount of ESD to mint
      */
     function mint(uint256 amount) external nonReentrant {
@@ -119,6 +121,7 @@ contract ReserveComptroller is ReentrancyGuard, ReserveAccessors, ReserveVault {
      * @notice Burns `amount` ESD from the caller in exchange for USDC at the rate of {redeemPrice}
      * @dev Non-reentrant
      *      Normalizes for decimals
+     *      Caller must approve reserve to transfer ESD
      * @param amount Amount of ESD to mint
      */
     function redeem(uint256 amount) external nonReentrant {

--- a/protocol/contracts/src/reserve/ReserveIssuer.sol
+++ b/protocol/contracts/src/reserve/ReserveIssuer.sol
@@ -46,6 +46,8 @@ contract ReserveIssuer is ReentrancyGuard, ReserveAccessors {
      * @notice Mints new ESDS tokens to a specified `account`
      * @dev Non-reentrant
      *      Owner only - governance hook
+     *      ESDS maxes out at ~79b total supply (2^96/10^18) due to its 96-bit limitation
+     *      Will revert if totalSupply exceeds this maximum
      * @param account Account to mint ESDS to
      * @param amount Amount of ESDS to mint
      */

--- a/protocol/contracts/src/reserve/ReserveSwapper.sol
+++ b/protocol/contracts/src/reserve/ReserveSwapper.sol
@@ -28,7 +28,11 @@ import "./ReserveState.sol";
 
 /**
  * @title ReserveSwapper
- * @notice Logic for managing outstanding limit orders, allow the reserve to swap its held tokens
+ * @notice Logic for managing outstanding reserve limit orders.
+ *         Since the reserve is autonomous, it cannot use traditional DEXs without being front-run. The `ReserveSwapper`
+ *         allows governance to place outstanding limit orders selling reserve assets in exchange for assets the reserve
+ *         wishes to purchase. This is the main mechanism by which the reserve may diversify itself, or buy back ESDS
+ *         using generated rewards.
  */
 contract ReserveSwapper is ReentrancyGuard, ReserveComptroller {
     using SafeMath for uint256;
@@ -48,11 +52,10 @@ contract ReserveSwapper is ReentrancyGuard, ReserveComptroller {
     /**
      * @notice Sets the `price` and `amount` of the specified `makerToken`-`takerToken` order
      * @dev Owner only - governance hook
-     *      uint256(-1) indicates an unlimited order amount
      * @param makerToken Token that the reserve wishes to sell
      * @param takerToken Token that the reserve wishes to buy
      * @param price Price as a ratio of takerAmount:makerAmount times 10^18
-     * @param amount Amount to decrement in ESD
+     * @param amount Amount of the makerToken that reserve wishes to sell - uint256(-1) indicates all reserve funds
      */
     function registerOrder(address makerToken, address takerToken, uint256 price, uint256 amount) external onlyOwner {
         _updateOrder(makerToken, takerToken, price, amount);
@@ -66,7 +69,6 @@ contract ReserveSwapper is ReentrancyGuard, ReserveComptroller {
      *      Uses the state-defined price for the `makerToken`-`takerToken` order
      *      Maker and taker tokens must be different
      *      Cannot swap ESD
-     *      uint256(-1) indicates an unlimited order amount
      * @param makerToken Token that the caller wishes to buy
      * @param takerToken Token that the caller wishes to sell
      * @param takerAmount Amount of takerToken to sell


### PR DESCRIPTION
- Improves general description of the `ReserveSwapper` functionality.
- Corrects `amount` parameter description for `ReserveSwapper` orders.
- Adds note in `ReserveIssuer` that ESDS totalSupply has a `96-bit` limit.
- Clarifies the formula for `redeemPrice` in the documentation.
- Specifies approval requirements for `mint` and `redeem` in `ReserveComptroller`.