### PR TITLE
Remove 'Dollar' from names

### DIFF
--- a/protocol/contracts/src/common/Implementation.sol
+++ b/protocol/contracts/src/common/Implementation.sol
@@ -51,17 +51,17 @@ contract Implementation {
     /**
      * @notice Storage slot with the owner of the contract
      */
-    bytes32 private constant OWNER_SLOT = keccak256("emptysetdollar.v2.implementation.owner");
+    bytes32 private constant OWNER_SLOT = keccak256("emptyset.v2.implementation.owner");
 
     /**
      * @notice Storage slot with the owner of the contract
      */
-    bytes32 private constant REGISTRY_SLOT = keccak256("emptysetdollar.v2.implementation.registry");
+    bytes32 private constant REGISTRY_SLOT = keccak256("emptyset.v2.implementation.registry");
 
     /**
      * @notice Storage slot with the owner of the contract
      */
-    bytes32 private constant NOT_ENTERED_SLOT = keccak256("emptysetdollar.v2.implementation.notEntered");
+    bytes32 private constant NOT_ENTERED_SLOT = keccak256("emptyset.v2.implementation.notEntered");
 
     // UPGRADEABILITY
 

--- a/protocol/contracts/src/governance/GovernorAlpha.sol
+++ b/protocol/contracts/src/governance/GovernorAlpha.sol
@@ -30,7 +30,7 @@ contract GovernorAlpha {
      */
 
     /// @notice The name of this contract
-    string public constant name = "Empty Set Dollar Governor Alpha";
+    string public constant name = "Empty Set Governor Alpha";
 
     /// @notice The number of votes in support of a proposal required in order for a quorum to be reached and for a vote to succeed
     /// @dev Initial ESDS supply will be approximately 1.6b - 2.0b depending on initial incentive programs

--- a/protocol/test/vester/Vester.test.js
+++ b/protocol/test/vester/Vester.test.js
@@ -12,7 +12,7 @@ const ONE_UNIT = ONE_BIP.mul(new BN(10000));
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const { MAX_UINT256 } = constants
 
-describe.only('Vester', function () {
+describe('Vester', function () {
   this.retries(10);
   this.timeout(5000);
 


### PR DESCRIPTION
Removes the string 'Dollar' from:
- `GovernorAlpha` name
- unstructured storage namespaces

NOTE: This is not covered by the audit, however only naming changes have occurred in the code.