### PR TITLE
Trusted Borrow Functionality

### DIFF
--- a/protocol/contracts/mock/reserve/MockReserveState.sol
+++ b/protocol/contracts/mock/reserve/MockReserveState.sol
@@ -31,6 +31,16 @@ contract MockReserveState is ReserveAccessors {
         super._decrementOrderAmount(makerToken, takerToken, amount, reason);
     }
 
+    // COMPTROLLER
+
+    function incrementDebtE(address borrower, uint256 amount) external {
+        super._incrementDebt(borrower, amount);
+    }
+
+    function decrementDebtE(address borrower, uint256 amount, string calldata reason) external {
+        super._decrementDebt(borrower, amount, reason);
+    }
+
     // IMPLEMENTATION
 
     function setRegistryE(address implementation) external {

--- a/protocol/contracts/src/reserve/ReserveComptroller.sol
+++ b/protocol/contracts/src/reserve/ReserveComptroller.sol
@@ -254,7 +254,12 @@ contract ReserveComptroller is ReserveAccessors, ReserveVault {
 
     function _canBorrow(address account, uint256 amount) private view returns (bool) {
         uint256 totalBorrowAmount = debt(account).add(amount);
-        if (account == address(1) && totalBorrowAmount <= 1_000_000e18) return true; // TODO: WrapOnlyBatcher
+
+        if ( // WrapOnlyBatcher
+            account == address(0x0B663CeaCEF01f2f88EB7451C70Aa069f19dB997) &&
+            totalBorrowAmount <= 1_000_000e18
+        ) return true;
+
         return false;
     }
 }

--- a/protocol/contracts/src/reserve/ReserveState.sol
+++ b/protocol/contracts/src/reserve/ReserveState.sol
@@ -157,7 +157,7 @@ contract ReserveAccessors is Implementation, ReserveState {
      * @param reason revert reason
      */
     function _decrementDebt(address borrower, uint256 amount, string memory reason) internal {
-        _state.totalDebt = _state.totalDebt.sub(amount);
+        _state.totalDebt = _state.totalDebt.sub(amount, reason);
         _state.debt[borrower] = _state.debt[borrower].sub(amount, reason);
     }
 }

--- a/protocol/test-environment.config.js
+++ b/protocol/test-environment.config.js
@@ -2,6 +2,9 @@ module.exports = {
   accounts: {
     ether: 1e6,
   },
+  node: {
+    unlocked_accounts: ['0x0000000000000000000000000000000000000001'], // TODO: fill in after deployment
+  },
 
   contracts: {
     type: 'truffle',

--- a/protocol/test-environment.config.js
+++ b/protocol/test-environment.config.js
@@ -3,7 +3,7 @@ module.exports = {
     ether: 1e6,
   },
   node: {
-    unlocked_accounts: ['0x0000000000000000000000000000000000000001'], // TODO: fill in after deployment
+    unlocked_accounts: ['0x0B663CeaCEF01f2f88EB7451C70Aa069f19dB997'], // WrapOnlyBatcher
   },
 
   contracts: {

--- a/protocol/test/incentivizer/Incentivizer.test.js
+++ b/protocol/test/incentivizer/Incentivizer.test.js
@@ -18,7 +18,7 @@ const ONE_UNIT = ONE_BIP.mul(new BN(10000));
  */
 describe('Incentivizer', function () {
   this.retries(10);
-  this.timeout(5000);
+  this.timeout(10000);
 
   const [ ownerAddress, userAddress, userAddress2 ] = accounts;
 

--- a/protocol/test/migrator/Migrator.test.js
+++ b/protocol/test/migrator/Migrator.test.js
@@ -14,7 +14,7 @@ const ONE_BIP = new BN(10).pow(new BN(14));
 const ONE_UNIT = ONE_BIP.mul(new BN(10000));
 
 describe('Migrator', function () {
-  this.timeout(5000);
+  this.timeout(10000);
 
   const [ ownerAddress, userAddress1, userAddress2, userAddress3 ] = accounts;
 

--- a/protocol/test/reserve/ReserveComptroller.test.js
+++ b/protocol/test/reserve/ReserveComptroller.test.js
@@ -312,6 +312,21 @@ describe('ReserveComptroller', function () {
       });
     });
 
+    describe('not allowed to borrow amount', function () {
+      it('reverts', async function () {
+        await expectRevert(
+            this.comptroller.borrow(BATCHER_ADDRESS, ONE_UNIT.mul(new BN(1000001)), {from: ownerAddress}),
+            "ReserveComptroller: cant borrow");
+      });
+
+      it('reverts', async function () {
+        await this.comptroller.borrow(BATCHER_ADDRESS, ONE_UNIT.mul(new BN(500000)), {from: ownerAddress})
+        await expectRevert(
+            this.comptroller.borrow(BATCHER_ADDRESS, ONE_UNIT.mul(new BN(500001)), {from: ownerAddress}),
+            "ReserveComptroller: cant borrow");
+      });
+    });
+
     describe('not owner', function () {
       it('reverts', async function () {
         await expectRevert(
@@ -378,22 +393,6 @@ describe('ReserveComptroller', function () {
         });
 
         expect(event.args.repayAmount).to.be.bignumber.equal(ONE_UNIT.mul(new BN(100000)));
-      });
-    });
-
-    describe('account not allowed to borrow', function () {
-      it('reverts', async function () {
-        await expectRevert(
-            this.comptroller.repay(userAddress, ONE_UNIT.mul(new BN(100000)), {from: BATCHER_ADDRESS}),
-            "ReserveComptroller: cant repay");
-      });
-    });
-
-    describe('sender not allowed to borrow', function () {
-      it('reverts', async function () {
-        await expectRevert(
-            this.comptroller.repay(BATCHER_ADDRESS, ONE_UNIT.mul(new BN(100000)), {from: userAddress}),
-            "ReserveComptroller: cant repay");
       });
     });
   });

--- a/protocol/test/reserve/ReserveComptroller.test.js
+++ b/protocol/test/reserve/ReserveComptroller.test.js
@@ -304,11 +304,11 @@ describe('ReserveComptroller', function () {
       });
     });
 
-    describe('not batcher', function () {
+    describe('not allowed to borrow', function () {
       it('reverts', async function () {
         await expectRevert(
             this.comptroller.borrow(userAddress, ONE_UNIT.mul(new BN(100000)), {from: ownerAddress}),
-            "ReserveComptroller: not batcher");
+            "ReserveComptroller: cant borrow");
       });
     });
 
@@ -381,19 +381,19 @@ describe('ReserveComptroller', function () {
       });
     });
 
-    describe('not batcher', function () {
+    describe('account not allowed to borrow', function () {
       it('reverts', async function () {
         await expectRevert(
             this.comptroller.repay(userAddress, ONE_UNIT.mul(new BN(100000)), {from: BATCHER_ADDRESS}),
-            "ReserveComptroller: not batcher");
+            "ReserveComptroller: cant repay");
       });
     });
 
-    describe('not from batcher', function () {
+    describe('sender not allowed to borrow', function () {
       it('reverts', async function () {
         await expectRevert(
             this.comptroller.repay(BATCHER_ADDRESS, ONE_UNIT.mul(new BN(100000)), {from: userAddress}),
-            "ReserveComptroller: not batcher");
+            "ReserveComptroller: cant repay");
       });
     });
   });

--- a/protocol/test/reserve/ReserveComptroller.test.js
+++ b/protocol/test/reserve/ReserveComptroller.test.js
@@ -12,7 +12,7 @@ const MockReserveComptroller = contract.fromArtifact('MockReserveComptroller');
 const ONE_USDC = new BN(1000000);
 const ONE_BIP = new BN(10).pow(new BN(14));
 const ONE_UNIT = ONE_BIP.mul(new BN(10000));
-const BATCHER_ADDRESS = "0x0000000000000000000000000000000000000001"; // TODO: fill in address after deployment
+const BATCHER_ADDRESS = "0x0B663CeaCEF01f2f88EB7451C70Aa069f19dB997";
 
 describe('ReserveComptroller', function () {
   this.retries(10)

--- a/protocol/test/reserve/ReserveSwapper.test.js
+++ b/protocol/test/reserve/ReserveSwapper.test.js
@@ -12,7 +12,7 @@ const ONE_UNIT = ONE_BIP.mul(new BN(10000));
 const MAX_256 = new BN(2).pow(new BN(256)).sub(new BN(1));
 
 describe('ReserveSwapper', function () {
-  this.timeout(5000);
+  this.timeout(10000);
 
   const [ ownerAddress, userAddress ] = accounts;
 


### PR DESCRIPTION
### Pre-Mint Hooks

Adds `borrow` and `repay` hooks to the Empty Set, which allows `DSU` pre-minting to trusted contracts through governance.

This enables wrap / unwrap  batcher contracts which will be able to:
1) Significantly reduce wrap / unwrap gas costs on Ethereum L1
2) Support wrap / unwrap on other EVM compatible L!s and L2s

### Safety

This PR implements the generalized hooks, but currently hardcode-allows the initial batcher contract to discourage abuse until this feature and the protocol itself is more mature.

### To Do

- [x] Update initial batcher contract address once deployed.

